### PR TITLE
Fix world thread hang: thread safety + receiver cache

### DIFF
--- a/src/main/java/com/mystichorizons/mysticnametags/listeners/PlayerListener.java
+++ b/src/main/java/com/mystichorizons/mysticnametags/listeners/PlayerListener.java
@@ -12,6 +12,7 @@ import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.mystichorizons.mysticnametags.MysticNameTagsPlugin;
+import com.mystichorizons.mysticnametags.nameplate.packet.PacketGlyphSender;
 import com.mystichorizons.mysticnametags.integrations.IntegrationManager;
 import com.mystichorizons.mysticnametags.nameplate.GlyphNameplateManager;
 import com.mystichorizons.mysticnametags.playtime.PlaytimeService;
@@ -272,5 +273,6 @@ public class PlayerListener {
         }
 
         TagManager.get().untrackOnlinePlayer(uuid);
+        PacketGlyphSender.evictReceiverCache(uuid);
     }
 }

--- a/src/main/java/com/mystichorizons/mysticnametags/nameplate/packet/PacketGlyphSender.java
+++ b/src/main/java/com/mystichorizons/mysticnametags/nameplate/packet/PacketGlyphSender.java
@@ -10,21 +10,27 @@ import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class PacketGlyphSender {
 
     private static volatile boolean packetGlyphsRuntimeDisabled = false;
     private static final boolean PACKET_CANARY_ONLY = true;
 
+    // cache the receiver per player so we don't do the reflective graph walk every packet
+    private static final Map<UUID, IPacketReceiver> receiverCache = new ConcurrentHashMap<>();
+
     private PacketGlyphSender() {
     }
 
     public static boolean isRuntimeDisabled() {
         return packetGlyphsRuntimeDisabled;
+    }
+
+    /** Drop cached receiver for a player. Call on disconnect. */
+    public static void evictReceiverCache(@Nonnull UUID uuid) {
+        receiverCache.remove(uuid);
     }
 
     @Nonnull
@@ -127,15 +133,25 @@ public final class PacketGlyphSender {
         }
 
         try {
-            IPacketReceiver receiver = findPacketReceiver(viewer, 0, new IdentityHashMap<>());
+            UUID viewerUuid = viewer.getUuid();
+            IPacketReceiver receiver = viewerUuid != null ? receiverCache.get(viewerUuid) : null;
             if (receiver == null) {
-                disableRuntime("no IPacketReceiver found", null);
-                return false;
+                // reflective discovery is expensive, only do it once per player
+                receiver = findPacketReceiver(viewer, 0, new IdentityHashMap<>());
+                if (receiver == null) {
+                    disableRuntime("no IPacketReceiver found", null);
+                    return false;
+                }
+                if (viewerUuid != null) {
+                    receiverCache.put(viewerUuid, receiver);
+                }
             }
 
             receiver.writeNoCache(toClientPacket);
             return true;
         } catch (Throwable t) {
+            // stale cache entry maybe, clear it and let next call rediscover
+            try { if (viewer.getUuid() != null) receiverCache.remove(viewer.getUuid()); } catch (Exception ignored) {}
             disableRuntime("packet write failed", t);
             return false;
         }

--- a/src/main/java/com/mystichorizons/mysticnametags/nameplate/packet/PacketGlyphState.java
+++ b/src/main/java/com/mystichorizons/mysticnametags/nameplate/packet/PacketGlyphState.java
@@ -3,15 +3,19 @@ package com.mystichorizons.mysticnametags.nameplate.packet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class PacketGlyphState {
 
-    private final Map<UUID, Map<Integer, ViewerState>> viewersBySubject = new HashMap<>();
+    // Must be thread-safe: follow() reads on world thread,
+    // forget()/clearSubject() writes from disconnect event thread.
+    // Plain HashMap causes infinite loop in get() under concurrent modification.
+    private final Map<UUID, Map<Integer, ViewerState>> viewersBySubject = new ConcurrentHashMap<>();
 
     @Nonnull
     public ViewerState viewer(@Nonnull UUID subjectUuid, int viewerNetworkId, @Nonnull UUID viewerUuid) {
         ViewerState state = viewersBySubject
-                .computeIfAbsent(subjectUuid, ignored -> new HashMap<>())
+                .computeIfAbsent(subjectUuid, ignored -> new ConcurrentHashMap<>())
                 .computeIfAbsent(viewerNetworkId, ignored -> new ViewerState(viewerNetworkId, viewerUuid));
 
         state.viewerUuid = viewerUuid;


### PR DESCRIPTION
Two fixes for the world thread freeze on the packet-based branch.

**HashMap -> ConcurrentHashMap in PacketGlyphState**

`viewersBySubject` was a plain HashMap read from the world thread (follow tasks) and written from the event thread (disconnect calling forget/clearSubject directly, not through world.execute). Concurrent structural modification on HashMap can put get() into an infinite loop, permanently freezing the world thread. Switched to ConcurrentHashMap, inner maps too.

**Cache IPacketReceiver per player in PacketGlyphSender**

`findPacketReceiver` does a reflective BFS over the PlayerRef object graph (all zero-arg methods + all fields, depth 3) every single packet send. With 20 players that's hundreds of reflective traversals per tick. The receiver for a player doesn't change during a session, so now it's cached on first lookup and evicted on disconnect.